### PR TITLE
Add 3D relative-input tracking mode and UI toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
 # auto-object-focus
-Automatic auto focuse on given object project
+
+Automatic cursor focusing on detected objects displayed on your screen using YOLOv8.
+The controller nudges the mouse relative to its current position so the chosen object
+is guided back toward the screen centre, moving faster when the target is far away and
+slowing down as it settles. You can operate the desktop pointer directly or emit
+relative 3D-style input for games that lock the cursor to the middle of the screen.
+
+## Installation
+
+```bash
+pip install .
+```
+
+This project requires the following main dependencies which will be installed automatically:
+
+- [ultralytics](https://github.com/ultralytics/ultralytics) (YOLOv8)
+- [opencv-python](https://pypi.org/project/opencv-python/)
+- [numpy](https://numpy.org/)
+- [pyautogui](https://pyautogui.readthedocs.io/)
+- [gradio](https://gradio.app/) for the optional web interface
+- [pynput](https://pypi.org/project/pynput/) for global hotkey support
+- [mss](https://github.com/BoboTiG/python-mss) for efficient screen capture (falls back to `pyautogui.screenshot` when unavailable)
+
+## Usage
+
+Run the controller with the desired class name:
+
+```bash
+python -m auto_focus.cli --class person
+```
+
+Additional options include:
+
+- `--class-id` to specify the numeric class identifier instead of a name.
+- `--confidence` to adjust the minimum detection confidence (default `0.5`).
+- `--smoothing` to control the exponential moving average factor (default `0.2`).
+- `--tracking-speed` to define the base movement speed (default `0.2`).
+- `--distance-ratio` to scale how much faster the cursor moves when the target is far from the center (default `2.0`).
+- `--model` to provide a custom YOLO weights file.
+- `--mode` to switch between the desktop cursor controller (`2d`, default) and a relative-input controller suited for 3D
+  applications (`3d`).
+
+Press `Ctrl+C` to stop the controller.
+
+## Web interface
+
+Launch the interactive Gradio interface to configure the tracker, adjust motion parameters, and register hotkeys:
+
+```bash
+python -m auto_focus.webui
+```
+
+### Windows quick launch
+
+Windows users can double-click `run.bat` to automatically verify that the required Python packages are installed and launch the Gradio web interface. The script installs any missing dependencies before starting the app so a single click opens the UI.
+
+The interface provides:
+
+- Text inputs for the target class or ID and model weights.
+- Sliders controlling the detection confidence, smoothing factor, base tracking speed, and far/near speed ratio.
+- A mode selector to choose between 2D cursor movement and 3D relative-input output for games that lock the pointer.
+- Text boxes for assigning start and stop keyboard shortcuts (one or two keys separated by `+`).
+- Buttons to start/stop the controller and apply hotkey changes. Global shortcuts trigger the same actions even when the interface is not focused.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "auto-object-focus"
+version = "0.1.0"
+description = "Automatic cursor focusing using YOLO object detection"
+readme = "README.md"
+authors = [{ name = "Auto Focus" }]
+requires-python = ">=3.9"
+dependencies = [
+    "ultralytics",
+    "opencv-python",
+    "numpy",
+    "pyautogui",
+    "mss",
+    "gradio",
+    "pynput",
+]
+
+[project.urls]
+Homepage = "https://example.com/auto-object-focus"

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,48 @@
+@echo off
+setlocal
+
+rem Change directory to the location of this script
+cd /d "%~dp0"
+
+where python >nul 2>&1
+if errorlevel 1 (
+    echo Python 3.9 or higher is required but was not found in PATH.
+    pause
+    exit /b 1
+)
+
+python -c "import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)" >nul 2>&1
+if errorlevel 1 (
+    echo Python 3.9 or higher is required to run Auto Object Focus.
+    pause
+    exit /b 1
+)
+
+set "MISSING="
+for /f "delims=" %%i in ('python -c "import importlib.util; mapping={'ultralytics':'ultralytics','cv2':'opencv-python','numpy':'numpy','pyautogui':'pyautogui','mss':'mss','gradio':'gradio','pynput':'pynput'}; missing=[pkg for mod,pkg in mapping.items() if importlib.util.find_spec(mod) is None]; print(' '.join(missing))"') do set "MISSING=%%i"
+
+if defined MISSING (
+    echo Missing dependencies detected: %MISSING%
+    echo Installing required packages. This may take a moment...
+    python -m pip install %MISSING%
+    if errorlevel 1 (
+        echo Failed to install the required Python packages.
+        pause
+        exit /b 1
+    )
+) else (
+    echo All Python dependencies are already installed.
+)
+
+set "PYTHONPATH=%~dp0src;%PYTHONPATH%"
+
+echo Launching the Auto Object Focus web interface...
+python -m auto_focus.webui
+if errorlevel 1 (
+    echo Failed to start the Auto Object Focus web interface.
+    pause
+    exit /b 1
+)
+
+pause
+exit /b 0

--- a/src/auto_focus/__init__.py
+++ b/src/auto_focus/__init__.py
@@ -1,0 +1,13 @@
+"""Auto focus package for cursor control using object detection."""
+
+from .controller import AutoFocusController
+
+__all__ = ["AutoFocusController", "launch_interface"]
+
+
+def launch_interface(*args, **kwargs):
+    """Lazy import the web UI launcher to avoid circular imports."""
+
+    from .webui import launch_interface as _launch_interface
+
+    return _launch_interface(*args, **kwargs)

--- a/src/auto_focus/cli.py
+++ b/src/auto_focus/cli.py
@@ -1,0 +1,78 @@
+"""Command line interface for the auto focus controller."""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Optional
+
+from .controller import AutoFocusController
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    """Parse command line arguments for the CLI."""
+
+    parser = argparse.ArgumentParser(description="Automatically focus the cursor on a detected object.")
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument("--class", dest="target_class", help="Name of the class to track (e.g. 'person').")
+    group.add_argument("--class-id", dest="target_class_id", type=int, help="Numeric class id to track.")
+    parser.add_argument("--confidence", type=float, default=0.5, help="Minimum detection confidence.")
+    parser.add_argument(
+        "--smoothing",
+        type=float,
+        default=0.2,
+        help="Smoothing factor between 0 and 1 controlling cursor responsiveness.",
+    )
+    parser.add_argument(
+        "--tracking-speed",
+        type=float,
+        default=0.2,
+        help="Base relative tracking speed (fraction of the screen per update) applied even when the target is near the center.",
+    )
+    parser.add_argument(
+        "--distance-ratio",
+        type=float,
+        default=2.0,
+        help="Additional speed scaling based on how far the detection is from the center.",
+    )
+    parser.add_argument(
+        "--model",
+        default="yolov8n.pt",
+        help="Path to the YOLO model weights (default: yolov8n.pt).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["2d", "3d"],
+        default="2d",
+        help="Choose between moving the desktop cursor (2d) or emitting relative input for 3D applications.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point."""
+
+    args = parse_args(argv)
+    target = args.target_class if args.target_class is not None else args.target_class_id
+
+    controller = AutoFocusController(
+        target_class=target,
+        confidence_threshold=args.confidence,
+        smoothing_factor=args.smoothing,
+        tracking_speed=args.tracking_speed,
+        distance_ratio=args.distance_ratio,
+        model_path=args.model,
+        mode=args.mode,
+    )
+
+    try:
+        controller.run()
+    except KeyboardInterrupt:
+        print("Interrupted by user. Shutting down...", file=sys.stderr)
+    finally:
+        controller.close()
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/auto_focus/controller.py
+++ b/src/auto_focus/controller.py
@@ -1,0 +1,417 @@
+"""Controller module for automatically focusing the cursor on detected objects."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import threading
+from typing import Callable, Dict, Iterable, Optional, Tuple, Union
+
+import numpy as np
+
+try:
+    from ultralytics import YOLO
+except ImportError as exc:  # pragma: no cover - handled at runtime
+    raise ImportError(
+        "ultralytics is required to use AutoFocusController. Install the optional dependencies first."
+    ) from exc
+
+try:
+    import cv2
+except ImportError as exc:  # pragma: no cover - handled at runtime
+    raise ImportError(
+        "opencv-python is required to use AutoFocusController. Install the optional dependencies first."
+    ) from exc
+
+try:  # pragma: no cover - optional runtime dependency
+    import mss  # type: ignore
+except ImportError:  # pragma: no cover - handled by falling back to pyautogui
+    mss = None
+
+try:
+    import pyautogui
+except ImportError as exc:  # pragma: no cover - handled at runtime
+    raise ImportError(
+        "pyautogui is required to use AutoFocusController. Install the optional dependencies first."
+    ) from exc
+
+
+@dataclass
+class BoundingBox:
+    """Normalized bounding box and confidence information."""
+
+    center_x: float
+    center_y: float
+    confidence: float
+
+
+FrameProvider = Callable[[], Optional[np.ndarray]]
+
+
+class AutoFocusController:
+    """Automatically keep the mouse cursor centered on a detected object."""
+
+    def __init__(
+        self,
+        target_class: Optional[Union[str, int]] = None,
+        *,
+        confidence_threshold: float = 0.5,
+        smoothing_factor: float = 0.2,
+        tracking_speed: float = 0.2,
+        distance_ratio: float = 2.0,
+        model_path: str = "yolov8n.pt",
+        mode: str = "2d",
+        cursor_controller: Optional[object] = None,
+        frame_provider: Optional[FrameProvider] = None,
+    ) -> None:
+        """Create a new controller instance.
+
+        Parameters
+        ----------
+        target_class:
+            Name or numeric identifier of the class to track. When ``None`` the first
+            detected class with sufficient confidence will be used.
+        confidence_threshold:
+            Minimum detection confidence for the class to be considered.
+        smoothing_factor:
+            Exponential smoothing factor between 0 and 1 used to smooth cursor motion.
+        tracking_speed:
+            Base relative cursor movement speed applied even when detections are close to the
+            frame centre. Expressed as a fraction of the screen size moved per update.
+        distance_ratio:
+            Additional scaling applied to the cursor speed based on how far the detection is
+            from the centre. Larger values accelerate more aggressively when the object is far.
+        model_path:
+            Path to the YOLO model weights.
+        cursor_controller:
+            Optional module-like object implementing the subset of the :mod:`pyautogui`
+            API used by the controller. Useful for testing.
+        frame_provider:
+            Optional callable returning the next video frame as a NumPy array. When not
+            supplied a screenshot-based provider is used to track objects displayed on
+            the screen.
+        mode:
+            ``"2d"`` moves the desktop cursor toward the detection. ``"3d"`` emits
+            relative mouse input and recentres the pointer so games that lock the
+            cursor keep their aim aligned with the detected target.
+        """
+
+        if not 0 < smoothing_factor <= 1:
+            raise ValueError("smoothing_factor must be between 0 (exclusive) and 1 (inclusive)")
+        if not 0 <= confidence_threshold <= 1:
+            raise ValueError("confidence_threshold must be between 0 and 1")
+
+        if not 0 < tracking_speed <= 1:
+            raise ValueError("tracking_speed must be between 0 (exclusive) and 1 (inclusive)")
+        if distance_ratio < 0:
+            raise ValueError("distance_ratio must be non-negative")
+
+        mode_normalized = mode.lower()
+        if mode_normalized not in {"2d", "3d"}:
+            raise ValueError("mode must be either '2d' or '3d'")
+
+        self.model = YOLO(model_path)
+        self.model_target = target_class
+        self.confidence_threshold = confidence_threshold
+        self.smoothing_factor = smoothing_factor
+        self.tracking_speed = tracking_speed
+        self.distance_ratio = distance_ratio
+        self.cursor_controller = cursor_controller if cursor_controller is not None else pyautogui
+        self.mode = mode_normalized
+
+        self.screen_width, self.screen_height = self._normalize_screen_size(self.cursor_controller.size())
+        self._screen_center = np.array([self.screen_width / 2.0, self.screen_height / 2.0], dtype=float)
+        self._smoothed_offset = np.zeros(2, dtype=float)
+        self._running = False
+        self._closed = False
+        self._frame_provider = frame_provider if frame_provider is not None else self._create_frame_provider()
+        self._frame_provider_close = getattr(self._frame_provider, "close", None)
+
+    def run(self) -> None:
+        """Start capturing screen frames and updating the cursor position."""
+
+        self._running = True
+        try:
+            while self._running:
+                try:
+                    frame = self._frame_provider()
+                except StopIteration:
+                    break
+
+                if frame is None:
+                    break
+
+                box = self._select_target_box(frame)
+                if box is None:
+                    continue
+
+                self._update_cursor(frame, box)
+        finally:
+            self.close()
+
+    def stop(self) -> None:
+        """Signal the controller loop to stop."""
+
+        self._running = False
+
+    def close(self) -> None:
+        """Release associated resources."""
+
+        if self._closed:
+            return
+
+        self.stop()
+
+        closer = self._frame_provider_close
+        if callable(closer):
+            closer()
+            self._frame_provider_close = None
+        if hasattr(cv2, "destroyAllWindows"):
+            cv2.destroyAllWindows()
+
+        self._closed = True
+
+    def update_motion_parameters(
+        self,
+        *,
+        tracking_speed: Optional[float] = None,
+        distance_ratio: Optional[float] = None,
+    ) -> None:
+        """Update motion-related parameters while the controller is running."""
+
+        if tracking_speed is not None:
+            if not 0 < tracking_speed <= 1:
+                raise ValueError("tracking_speed must be between 0 (exclusive) and 1 (inclusive)")
+            self.tracking_speed = float(tracking_speed)
+
+        if distance_ratio is not None:
+            if distance_ratio < 0:
+                raise ValueError("distance_ratio must be non-negative")
+            self.distance_ratio = float(distance_ratio)
+
+    def _select_target_box(self, frame: np.ndarray) -> Optional[BoundingBox]:
+        """Run the YOLO model on the frame and select the best matching bounding box."""
+
+        results = self.model(frame)
+        if not results:
+            return None
+
+        target_id = self._resolve_target_id()
+        best_box: Optional[BoundingBox] = None
+
+        for result in results:
+            boxes = getattr(result, "boxes", None)
+            if boxes is None:
+                continue
+
+            class_ids = self._to_numpy(getattr(boxes, "cls", []))
+            confidences = self._to_numpy(getattr(boxes, "conf", []))
+            coords = self._to_numpy(getattr(boxes, "xyxy", []))
+            if len(coords) == 0:
+                continue
+
+            names = self._get_names_mapping(result)
+
+            for coord, confidence, class_id in zip(coords, confidences, class_ids):
+                if confidence < self.confidence_threshold:
+                    continue
+
+                if target_id is not None and int(class_id) != target_id:
+                    continue
+
+                if target_id is None and self.model_target is not None:
+                    class_name = names.get(int(class_id), str(class_id)) if names else str(class_id)
+                    if str(self.model_target).lower() != str(class_name).lower():
+                        continue
+
+                x1, y1, x2, y2 = coord
+                center_x = (x1 + x2) / 2.0
+                center_y = (y1 + y2) / 2.0
+                candidate = BoundingBox(center_x=center_x, center_y=center_y, confidence=float(confidence))
+
+                if best_box is None or candidate.confidence > best_box.confidence:
+                    best_box = candidate
+
+        return best_box
+
+    def _update_cursor(self, frame: np.ndarray, box: BoundingBox) -> None:
+        """Smooth the detected offset and move the cursor accordingly."""
+
+        frame_height, frame_width = frame.shape[:2]
+        frame_center = np.array([frame_width / 2.0, frame_height / 2.0])
+        detection_center = np.array([box.center_x, box.center_y])
+        offset_pixels = detection_center - frame_center
+        normalized_offset = offset_pixels / np.array([frame_width, frame_height])
+
+        self._smoothed_offset = (
+            (1 - self.smoothing_factor) * self._smoothed_offset
+            + self.smoothing_factor * normalized_offset
+        )
+
+        distance_norm = float(np.linalg.norm(self._smoothed_offset))
+        effective_speed = max(0.0, self.tracking_speed + self.distance_ratio * distance_norm)
+        effective_speed = min(effective_speed, 1.0)
+
+        move_vector = self._smoothed_offset * effective_speed * np.array(
+            [self.screen_width, self.screen_height],
+            dtype=float,
+        )
+
+        if np.allclose(move_vector, 0.0):
+            if self.mode == "3d" and hasattr(self.cursor_controller, "moveTo"):
+                # Maintain the pointer in the centre so relative-only inputs stay anchored.
+                self.cursor_controller.moveTo(int(self._screen_center[0]), int(self._screen_center[1]))
+            return
+
+        if self.mode == "3d":
+            self._apply_3d_cursor_movement(move_vector)
+        else:
+            self._apply_2d_cursor_movement(move_vector)
+
+    def _apply_2d_cursor_movement(self, move_vector: np.ndarray) -> None:
+        """Move the cursor directly toward the detected object on the screen."""
+
+        if hasattr(self.cursor_controller, "moveRel"):
+            self.cursor_controller.moveRel(float(move_vector[0]), float(move_vector[1]))
+            return
+
+        current_position = self._get_cursor_position()
+        target_position = current_position + move_vector
+        clamped_position = np.clip(
+            target_position,
+            [0, 0],
+            [self.screen_width - 1, self.screen_height - 1],
+        )
+        self.cursor_controller.moveTo(int(clamped_position[0]), int(clamped_position[1]))
+
+    def _apply_3d_cursor_movement(self, move_vector: np.ndarray) -> None:
+        """Send relative mouse input while keeping the pointer centred on the screen."""
+
+        dx, dy = float(move_vector[0]), float(move_vector[1])
+
+        if hasattr(self.cursor_controller, "moveRel"):
+            self.cursor_controller.moveRel(dx, dy)
+
+        # When an application consumes relative input (e.g. a 3D game) the OS cursor is
+        # typically locked to the screen centre. Best effort re-centre the pointer so the
+        # next set of deltas continue from a neutral position even if the cursor is visible.
+        if hasattr(self.cursor_controller, "moveTo"):
+            self.cursor_controller.moveTo(int(self._screen_center[0]), int(self._screen_center[1]))
+
+    def _resolve_target_id(self) -> Optional[int]:
+        """Resolve the numeric class identifier for the configured target."""
+
+        if isinstance(self.model_target, int):
+            return int(self.model_target)
+
+        if isinstance(self.model_target, str):
+            names = self._get_model_names()
+            if names:
+                for class_id, class_name in names.items():
+                    if str(class_name).lower() == self.model_target.lower():
+                        return int(class_id)
+
+        return None
+
+    def _get_cursor_position(self) -> np.ndarray:
+        """Return the current cursor position as a NumPy array."""
+
+        position = self.cursor_controller.position()
+        if hasattr(position, "x") and hasattr(position, "y"):
+            x, y = float(position.x), float(position.y)
+        else:
+            x, y = position
+
+        return np.array([x, y], dtype=float)
+
+    def _get_model_names(self) -> Optional[Dict[int, str]]:
+        names = getattr(self.model, "names", None)
+        if isinstance(names, dict):
+            return {int(k): str(v) for k, v in names.items()}
+        return None
+
+    @staticmethod
+    def _get_names_mapping(result: object) -> Optional[Dict[int, str]]:
+        names = getattr(result, "names", None)
+        if isinstance(names, dict):
+            return {int(k): str(v) for k, v in names.items()}
+        return None
+
+    @staticmethod
+    def _normalize_screen_size(size: Union[Tuple[int, int], object]) -> Tuple[int, int]:
+        """Normalize the screen size returned by :mod:`pyautogui`."""
+
+        if hasattr(size, "width") and hasattr(size, "height"):
+            width = getattr(size, "width")
+            height = getattr(size, "height")
+        else:
+            width, height = size
+
+        return int(width), int(height)
+
+    @staticmethod
+    def _to_numpy(values: Union[np.ndarray, Iterable[float]]) -> np.ndarray:
+        """Convert framework-specific tensors to NumPy arrays."""
+
+        if values is None:
+            return np.empty((0,), dtype=float)
+
+        if hasattr(values, "cpu"):
+            values = values.cpu()
+        if hasattr(values, "numpy"):
+            values = values.numpy()
+
+        return np.asarray(values, dtype=float)
+
+    def _create_frame_provider(self) -> FrameProvider:
+        """Return the default frame provider capturing the primary screen."""
+
+        return _ScreenFrameProvider()
+
+
+class _ScreenFrameProvider:
+    """Capture frames from the primary monitor for object tracking."""
+
+    def __init__(self) -> None:
+        self._monitor = None
+        self._thread_local: Optional[threading.local] = None
+        self._scts = set()
+        self._scts_lock = threading.Lock()
+        if mss is not None:  # pragma: no branch - simple runtime selection
+            with mss.mss() as sct:
+                monitor = sct.monitors[0]
+            self._monitor = {
+                "left": monitor.get("left", 0),
+                "top": monitor.get("top", 0),
+                "width": monitor.get("width", 0),
+                "height": monitor.get("height", 0),
+            }
+            self._thread_local = threading.local()
+
+    def __call__(self) -> Optional[np.ndarray]:
+        if self._monitor is not None and self._thread_local is not None:
+            sct = getattr(self._thread_local, "sct", None)
+            if sct is None:
+                sct = mss.mss()
+                self._thread_local.sct = sct
+                with self._scts_lock:
+                    self._scts.add(sct)
+            shot = sct.grab(self._monitor)
+            frame = np.array(shot)
+            # mss returns BGRA frames.
+            return cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
+
+        # Fallback to pyautogui's screenshot functionality when mss is unavailable.
+        image = pyautogui.screenshot()
+        frame = np.array(image)
+        return cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+
+    def close(self) -> None:
+        if self._thread_local is not None and hasattr(self._thread_local, "sct"):
+            delattr(self._thread_local, "sct")
+        if self._scts:
+            with self._scts_lock:
+                while self._scts:
+                    sct = self._scts.pop()
+                    try:
+                        sct.close()
+                    except Exception:  # pragma: no cover - defensive cleanup
+                        pass

--- a/src/auto_focus/webui.py
+++ b/src/auto_focus/webui.py
@@ -1,0 +1,349 @@
+"""Gradio-powered interface for configuring and running the auto focus controller."""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Optional, Union
+
+try:
+    import gradio as gr
+except ImportError as exc:  # pragma: no cover - handled in runtime usage
+    raise ImportError(
+        "gradio is required to launch the web UI. Install the optional dependencies first."
+    ) from exc
+
+try:
+    from pynput import keyboard
+except ImportError as exc:  # pragma: no cover - handled in runtime usage
+    raise ImportError(
+        "pynput is required to use the hotkey functionality. Install the optional dependencies first."
+    ) from exc
+
+from .controller import AutoFocusController
+
+
+@dataclass
+class AppState:
+    """Mutable application state shared across callbacks."""
+
+    target: Optional[Union[str, int]] = None
+    confidence: float = 0.5
+    smoothing: float = 0.2
+    tracking_speed: float = 0.2
+    distance_ratio: float = 2.0
+    model_path: str = "yolov8n.pt"
+    mode: str = "2d"
+    def to_controller_kwargs(self) -> dict:
+        return {
+            "target_class": self.target,
+            "confidence_threshold": self.confidence,
+            "smoothing_factor": self.smoothing,
+            "tracking_speed": self.tracking_speed,
+            "distance_ratio": self.distance_ratio,
+            "model_path": self.model_path,
+            "mode": self.mode,
+        }
+
+
+class ControllerRunner:
+    """Manage the lifecycle of :class:`AutoFocusController` instances."""
+
+    def __init__(self) -> None:
+        self._controller: Optional[AutoFocusController] = None
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+
+    def start(self, **kwargs) -> tuple[bool, str]:
+        with self._lock:
+            if self._controller is not None:
+                return False, "Controller already running."
+
+            controller = AutoFocusController(**kwargs)
+            thread = threading.Thread(target=controller.run, daemon=True)
+            self._controller = controller
+            self._thread = thread
+            thread.start()
+
+        return True, "Controller started."
+
+    def stop(self) -> tuple[bool, str]:
+        with self._lock:
+            controller = self._controller
+            thread = self._thread
+            self._controller = None
+            self._thread = None
+
+        if controller is None:
+            return False, "Controller is not running."
+
+        controller.stop()
+        if thread is not None:
+            thread.join(timeout=2.0)
+        controller.close()
+        return True, "Controller stopped."
+
+    def update_motion(self, tracking_speed: float, distance_ratio: float) -> None:
+        with self._lock:
+            if self._controller is not None:
+                self._controller.update_motion_parameters(
+                    tracking_speed=tracking_speed, distance_ratio=distance_ratio
+                )
+
+
+class HotkeyManager:
+    """Register and manage global hotkeys using :mod:`pynput`."""
+
+    def __init__(self) -> None:
+        self._listener: Optional[keyboard.GlobalHotKeys] = None
+        self._lock = threading.Lock()
+
+    def configure(
+        self,
+        start_combo: Optional[str],
+        stop_combo: Optional[str],
+        on_start,
+        on_stop,
+    ) -> None:
+        with self._lock:
+            self._shutdown_unlocked()
+
+            hotkeys: dict[str, callable] = {}
+            if start_combo:
+                hotkeys[self._format_combo(start_combo)] = on_start
+            if stop_combo:
+                hotkeys[self._format_combo(stop_combo)] = on_stop
+
+            if hotkeys:
+                listener = keyboard.GlobalHotKeys(hotkeys)
+                listener.start()
+                self._listener = listener
+
+    def shutdown(self) -> None:
+        with self._lock:
+            self._shutdown_unlocked()
+
+    def _shutdown_unlocked(self) -> None:
+        if self._listener is not None:
+            self._listener.stop()
+            self._listener = None
+
+    @staticmethod
+    def _format_combo(combo: str) -> str:
+        tokens = [token.strip().lower() for token in combo.split("+") if token.strip()]
+        if not 1 <= len(tokens) <= 2:
+            raise ValueError("Hotkeys must contain one or two keys separated by '+'.")
+
+        replacements = {
+            "ctrl": "<ctrl>",
+            "control": "<ctrl>",
+            "shift": "<shift>",
+            "alt": "<alt>",
+            "option": "<alt>",
+            "cmd": "<cmd>",
+            "command": "<cmd>",
+            "win": "<cmd>",
+        }
+
+        mapped = [replacements.get(token, token) for token in tokens]
+        return "+".join(mapped)
+
+
+def _parse_target(value: Optional[str]) -> Optional[Union[str, int]]:
+    if value is None:
+        return None
+    stripped = value.strip()
+    if not stripped:
+        return None
+    try:
+        return int(stripped)
+    except ValueError:
+        return stripped
+
+
+def launch_interface(**launch_kwargs) -> gr.Blocks:
+    """Launch the Gradio interface."""
+
+    runner = ControllerRunner()
+    hotkeys = HotkeyManager()
+    state = AppState()
+    state_lock = threading.Lock()
+
+    def _start_from_hotkey():  # pragma: no cover - side-effect callback
+        with state_lock:
+            params = state.to_controller_kwargs()
+        success, message = runner.start(**params)
+        if not success:
+            print(message)
+
+    def _stop_from_hotkey():  # pragma: no cover - side-effect callback
+        success, message = runner.stop()
+        if not success:
+            print(message)
+
+    def start_controller(
+        target_value: str,
+        confidence: float,
+        smoothing: float,
+        tracking_speed: float,
+        distance_ratio: float,
+        model_path: str,
+        mode: str,
+    ) -> str:
+        with state_lock:
+            state.target = _parse_target(target_value)
+            state.confidence = confidence
+            state.smoothing = smoothing
+            state.tracking_speed = tracking_speed
+            state.distance_ratio = distance_ratio
+            state.model_path = model_path.strip() or "yolov8n.pt"
+            state.mode = mode
+            params = state.to_controller_kwargs()
+
+        success, message = runner.start(**params)
+        return f"Status: {message}"
+
+    def stop_controller() -> str:
+        success, message = runner.stop()
+        return f"Status: {message}"
+
+    def update_motion(tracking_speed: float, distance_ratio: float) -> str:
+        with state_lock:
+            state.tracking_speed = tracking_speed
+            state.distance_ratio = distance_ratio
+        runner.update_motion(tracking_speed, distance_ratio)
+        return "Status: Updated tracking behaviour."
+
+    def register_hotkeys(start_combo: str, stop_combo: str) -> str:
+        try:
+            hotkeys.configure(start_combo, stop_combo, _start_from_hotkey, _stop_from_hotkey)
+        except ValueError as exc:
+            return f"Status: Hotkey error - {exc}" 
+        return "Status: Hotkeys registered."
+
+    def update_thresholds(confidence: float, smoothing: float) -> str:
+        with state_lock:
+            state.confidence = confidence
+            state.smoothing = smoothing
+        return "Status: Updated detection thresholds."
+
+    def update_mode(mode: str) -> str:
+        with state_lock:
+            state.mode = mode
+        return f"Status: Tracking mode set to {mode.upper()}."
+
+    def cleanup():  # pragma: no cover - triggered on UI shutdown
+        runner.stop()
+        hotkeys.shutdown()
+
+    with gr.Blocks(title="Auto Object Focus") as demo:
+        gr.Markdown(
+            "## Auto Object Focus\n"
+            "Configure YOLO powered cursor tracking, adjust motion behaviour, and register hotkeys."
+        )
+
+        with gr.Row():
+            target_input = gr.Textbox(label="Target Class or ID", value="person", placeholder="person")
+            model_input = gr.Textbox(label="YOLO Model", value="yolov8n.pt")
+
+        with gr.Row():
+            confidence_slider = gr.Slider(
+                minimum=0.0,
+                maximum=1.0,
+                value=0.5,
+                step=0.05,
+                label="Confidence Threshold",
+            )
+            smoothing_slider = gr.Slider(
+                minimum=0.05,
+                maximum=1.0,
+                value=0.2,
+                step=0.05,
+                label="Smoothing Factor",
+            )
+
+        with gr.Row():
+            tracking_slider = gr.Slider(
+                minimum=0.05,
+                maximum=1.0,
+                value=0.2,
+                step=0.05,
+                label="Tracking Speed",
+            )
+            distance_slider = gr.Slider(
+                minimum=0.0,
+                maximum=5.0,
+                value=2.0,
+                step=0.1,
+                label="Far/Near Speed Ratio",
+            )
+
+        mode_selector = gr.Radio(
+            choices=["2d", "3d"],
+            value="2d",
+            label="Tracking Mode",
+            info="2D moves the desktop cursor, 3D emits relative input for locked-pointer apps.",
+        )
+
+        with gr.Row():
+            start_hotkey = gr.Textbox(
+                label="Start Hotkey",
+                placeholder="e.g. ctrl+shift+s",
+            )
+            stop_hotkey = gr.Textbox(
+                label="Stop Hotkey",
+                placeholder="e.g. ctrl+shift+x",
+            )
+
+        status_display = gr.Markdown("Status: Idle")
+
+        with gr.Row():
+            start_button = gr.Button("Start", variant="primary")
+            stop_button = gr.Button("Stop")
+            hotkey_button = gr.Button("Apply Hotkeys")
+
+        start_button.click(
+            start_controller,
+            inputs=[
+                target_input,
+                confidence_slider,
+                smoothing_slider,
+                tracking_slider,
+                distance_slider,
+                model_input,
+                mode_selector,
+            ],
+            outputs=status_display,
+        )
+
+        stop_button.click(stop_controller, outputs=status_display)
+        hotkey_button.click(
+            register_hotkeys,
+            inputs=[start_hotkey, stop_hotkey],
+            outputs=status_display,
+        )
+
+        tracking_slider.change(update_motion, inputs=[tracking_slider, distance_slider], outputs=status_display)
+        distance_slider.change(update_motion, inputs=[tracking_slider, distance_slider], outputs=status_display)
+        confidence_slider.change(
+            update_thresholds, inputs=[confidence_slider, smoothing_slider], outputs=status_display
+        )
+        smoothing_slider.change(
+            update_thresholds, inputs=[confidence_slider, smoothing_slider], outputs=status_display
+        )
+        mode_selector.change(update_mode, inputs=mode_selector, outputs=status_display)
+
+    try:
+        demo.launch(**launch_kwargs)
+    finally:
+        cleanup()
+    return demo
+
+
+def main() -> None:
+    """Entry point for ``python -m auto_focus.webui``."""
+
+    launch_interface()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test configuration for auto_focus package."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the src directory is importable during tests.
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import List
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+
+def install_stubs(monkeypatch: pytest.MonkeyPatch):
+    """Install stub modules for external dependencies."""
+
+    class DummyBoxes:
+        def __init__(self, xyxy, conf, cls):
+            self.xyxy = np.array(xyxy, dtype=float)
+            self.conf = np.array(conf, dtype=float)
+            self.cls = np.array(cls, dtype=float)
+
+    class DummyResult:
+        def __init__(self, boxes):
+            self.boxes = boxes
+            self.names = {0: "person", 1: "dog"}
+
+    class DummyYOLO:
+        result_queue: List[DummyResult] = []
+
+        def __init__(self, model_path: str):
+            self.model_path = model_path
+            self.names = {0: "person", 1: "dog"}
+
+        def __call__(self, frame):
+            if not DummyYOLO.result_queue:
+                return []
+            result = DummyYOLO.result_queue.pop(0)
+            result.names = self.names
+            return [result]
+
+    class DummyCursor:
+        def __init__(self):
+            self.movements = []
+            self._position = np.array([960.0, 540.0])
+
+        def size(self):
+            return (1920, 1080)
+
+        def moveTo(self, x, y):
+            self.movements.append((x, y))
+            self._position = np.array([float(x), float(y)])
+
+        def moveRel(self, x, y):
+            self.movements.append(("rel", float(x), float(y)))
+
+        def position(self):
+            return tuple(self._position)
+
+    dummy_ultralytics = types.ModuleType("ultralytics")
+    dummy_ultralytics.YOLO = DummyYOLO
+    monkeypatch.setitem(sys.modules, "ultralytics", dummy_ultralytics)
+
+    dummy_cv2 = types.ModuleType("cv2")
+    dummy_cv2.COLOR_BGRA2BGR = 0
+    dummy_cv2.COLOR_RGB2BGR = 1
+
+    def _cvt_color(frame, code):
+        return frame
+
+    dummy_cv2.cvtColor = _cvt_color
+    dummy_cv2.destroyAllWindows = lambda: None
+    monkeypatch.setitem(sys.modules, "cv2", dummy_cv2)
+
+    dummy_cursor_module = types.ModuleType("pyautogui")
+    cursor = DummyCursor()
+    dummy_cursor_module.size = cursor.size
+    dummy_cursor_module.moveTo = cursor.moveTo
+    dummy_cursor_module.moveRel = cursor.moveRel
+    dummy_cursor_module.position = cursor.position
+    dummy_cursor_module.FAILSAFE = False
+    monkeypatch.setitem(sys.modules, "pyautogui", dummy_cursor_module)
+
+    return DummyYOLO, cursor
+
+
+class DummyFrameProvider:
+    def __init__(self, frames: List[np.ndarray]):
+        self._frames = frames
+        self._index = 0
+        self.closed = False
+
+    def __call__(self):
+        if self._index >= len(self._frames):
+            return None
+        frame = self._frames[self._index]
+        self._index += 1
+        return frame
+
+    def close(self):
+        self.closed = True
+
+
+def test_controller_moves_cursor_with_smoothing(monkeypatch: pytest.MonkeyPatch):
+    DummyYOLO, cursor = install_stubs(monkeypatch)
+
+    frames = [np.zeros((480, 640, 3), dtype=np.uint8) for _ in range(3)]
+    provider = DummyFrameProvider(frames)
+
+    controller_module = importlib.import_module("auto_focus.controller")
+    AutoFocusController = controller_module.AutoFocusController
+
+    controller_module.YOLO.result_queue = [
+        types.SimpleNamespace(
+            boxes=types.SimpleNamespace(
+                xyxy=np.array([[300, 200, 340, 280]], dtype=float),
+                conf=np.array([0.9], dtype=float),
+                cls=np.array([0], dtype=float),
+            ),
+            names={0: "person"},
+        ),
+        types.SimpleNamespace(
+            boxes=types.SimpleNamespace(
+                xyxy=np.array([[100, 200, 140, 280]], dtype=float),
+                conf=np.array([0.8], dtype=float),
+                cls=np.array([0], dtype=float),
+            ),
+            names={0: "person"},
+        ),
+        types.SimpleNamespace(
+            boxes=types.SimpleNamespace(
+                xyxy=np.empty((0, 4)),
+                conf=np.empty((0,)),
+                cls=np.empty((0,)),
+            ),
+            names={0: "person"},
+        ),
+    ]
+
+    controller = AutoFocusController(
+        target_class="person",
+        confidence_threshold=0.5,
+        smoothing_factor=0.5,
+        frame_provider=provider,
+        cursor_controller=cursor,
+        mode="2d",
+    )
+
+    controller.run()
+
+    assert provider.closed is True
+    assert len(cursor.movements) == 1
+
+    # Cursor should move left relative to its current position to recenter the detection.
+    kind, dx, dy = cursor.movements[0]
+    assert kind == "rel"
+    assert pytest.approx(dx, rel=1e-3) == -153.75
+    assert pytest.approx(dy, abs=1e-6) == 0.0
+
+
+def test_update_motion_parameters(monkeypatch: pytest.MonkeyPatch):
+    DummyYOLO, cursor = install_stubs(monkeypatch)
+
+    frames = [np.zeros((480, 640, 3), dtype=np.uint8)]
+    provider = DummyFrameProvider(frames)
+
+    controller_module = importlib.import_module("auto_focus.controller")
+    AutoFocusController = controller_module.AutoFocusController
+
+    controller_module.YOLO.result_queue = [
+        types.SimpleNamespace(
+            boxes=types.SimpleNamespace(
+                xyxy=np.array([[300, 200, 340, 280]], dtype=float),
+                conf=np.array([0.9], dtype=float),
+                cls=np.array([0], dtype=float),
+            ),
+            names={0: "person"},
+        )
+    ]
+
+    controller = AutoFocusController(
+        target_class="person",
+        confidence_threshold=0.5,
+        smoothing_factor=0.5,
+        tracking_speed=0.3,
+        distance_ratio=1.0,
+        frame_provider=provider,
+        cursor_controller=cursor,
+        mode="2d",
+    )
+
+    controller.update_motion_parameters(tracking_speed=0.5, distance_ratio=0.8)
+    assert controller.tracking_speed == pytest.approx(0.5)
+    assert controller.distance_ratio == pytest.approx(0.8)
+
+    with pytest.raises(ValueError):
+        controller.update_motion_parameters(tracking_speed=0)
+
+    with pytest.raises(ValueError):
+        controller.update_motion_parameters(distance_ratio=-1)
+
+
+def test_controller_3d_mode_recenters_pointer(monkeypatch: pytest.MonkeyPatch):
+    DummyYOLO, cursor = install_stubs(monkeypatch)
+
+    frames = [np.zeros((480, 640, 3), dtype=np.uint8)]
+    provider = DummyFrameProvider(frames)
+
+    controller_module = importlib.import_module("auto_focus.controller")
+    AutoFocusController = controller_module.AutoFocusController
+
+    controller_module.YOLO.result_queue = [
+        types.SimpleNamespace(
+            boxes=types.SimpleNamespace(
+                xyxy=np.array([[400, 240, 440, 280]], dtype=float),
+                conf=np.array([0.95], dtype=float),
+                cls=np.array([0], dtype=float),
+            ),
+            names={0: "person"},
+        )
+    ]
+
+    controller = AutoFocusController(
+        target_class="person",
+        confidence_threshold=0.5,
+        smoothing_factor=0.5,
+        tracking_speed=0.2,
+        distance_ratio=1.0,
+        frame_provider=provider,
+        cursor_controller=cursor,
+        mode="3d",
+    )
+
+    controller.run()
+
+    # Expect a relative move followed by a forced recenter of the pointer.
+    assert len(cursor.movements) == 2
+    kind, dx, dy = cursor.movements[0]
+    assert kind == "rel"
+    assert dx != 0 or dy != 0
+    x, y = cursor.movements[1]
+    assert pytest.approx(x, abs=1e-6) == 960.0
+    assert pytest.approx(y, abs=1e-6) == 540.0


### PR DESCRIPTION
## Summary
- extend the controller with a selectable 2D/3D tracking mode that supports relative-input re-centering for games
- expose the new mode through the CLI, documentation, and Gradio web UI including a toggle widget
- add regression coverage to ensure the 3D mode emits deltas and recenters the pointer while the 2D mode keeps existing behaviour

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1ff285a4c8329b4e345907d01bdbf